### PR TITLE
0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitterly"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "paste",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitterly"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Non-memory mapped bit manipulation library"
 repository = "https://github.com/BridgeSource/bitterly"

--- a/examples/max14748.rs
+++ b/examples/max14748.rs
@@ -13,6 +13,7 @@ pub fn main() {
 
     peripheral!(
         Max14748,
+        u8,
         0x0A,
         54,
         [

--- a/examples/max17261.rs
+++ b/examples/max17261.rs
@@ -43,6 +43,7 @@ pub fn main() {
 
     peripheral!(
         Max17261,
+        u8,
         0x36,
         112,
         [

--- a/examples/max17261.rs
+++ b/examples/max17261.rs
@@ -43,7 +43,7 @@ pub fn main() {
 
     peripheral!(
         Max17261,
-        0x0A,
+        0x36,
         112,
         [
             // 0x00 to 0x10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,9 @@ pub enum Errors {
 #[macro_export]
 macro_rules! register_backer {
     ($reg_name:ident, $reg_type:ty) => {
-        type RegisterType = $reg_type;
+        pub type RegisterType = $reg_type;
 
-        type RegisterBacker = $reg_name;
+        pub type RegisterBacker = $reg_name;
 
         #[derive(Copy, Clone)]
         pub struct $reg_name {
@@ -142,7 +142,7 @@ macro_rules! register_backer {
 macro_rules! peripheral {
     //($enum_name:ident, $enum_type:ty, [$(($name:ident, $value:literal)),+]) => {
 
-    ($peripheral_name:ident, $i2c_addr:literal, $count:literal, [$(($register:ident, $addr:literal, $index:literal)),+]) => {
+    ($peripheral_name:ident, $address_type:ty, $i2c_addr:literal, $count:literal, [$(($register:ident, $addr:literal, $index:literal)),+]) => {
         #[derive(Debug, Copy, Clone, PartialEq, Eq)]
         pub enum RegisterAddress {
             $(
@@ -159,24 +159,63 @@ macro_rules! peripheral {
 
         pub struct $peripheral_name {
             registers: [RegisterBacker; $count],
+            address_index: [$address_type; $count],
             i2c_addr: u16,
         }
 
         impl $peripheral_name {
             pub fn new() -> Self {
+                let mut address_index: [$address_type; $count] = [0; $count];
+
+                $(
+                    address_index[$index as usize] = $addr as $address_type;
+                )+
+
                 $peripheral_name {
                     registers: [RegisterBacker { contents: 0 }; $count],
+                    address_index,
                     i2c_addr: $i2c_addr,
                 }
             }
 
-            pub fn direct_update(&mut self, address: usize, val: RegisterType) -> &mut Self {
-                self.registers[address].update(val);
+            pub fn find_index_by_address(&self, address: usize) -> Option<usize> {
+                for i in 0..$count {
+                    if self.address_index[i] == address as $address_type {
+                        return Some(i);
+                    }
+                }
+
+                None
+            }
+
+            pub fn direct_update_by_address(&mut self, address: usize, val: RegisterType) -> &mut Self {
+                let index = self.find_index_by_address(address);
+                match index {
+                    Some(i) => {
+                        self.registers[i].update(val);
+                    },
+                    None => {
+                        panic!("Address not found");
+                    }
+                }
                 self
             }
 
-            pub fn direct_read(&self, address: usize) -> RegisterType {
-                self.registers[address].contents()
+            pub fn direct_read_by_address(&self, address: usize) -> RegisterType {
+                let index = self.find_index_by_address(address);
+                match index {
+                    Some(i) => {
+                        return self.registers[i].contents();
+                    },
+                    None => {
+                        panic!("Address not found");
+                    }
+                }
+            }
+
+            pub fn direct_update_by_index(&mut self, index: usize, val: RegisterType) -> &mut Self {
+                self.registers[index].update(val);
+                self
             }
 
             pub fn get_i2c_address(&self) -> u16 {

--- a/tests/bitterly.rs
+++ b/tests/bitterly.rs
@@ -58,6 +58,7 @@ mod tests {
 
         peripheral!(
             Max14748,
+            u8,
             0x0A,
             5,
             [
@@ -92,6 +93,7 @@ mod tests {
 
         peripheral!(
             Max14748,
+            u8,
             0x0A,
             5,
             [
@@ -144,6 +146,7 @@ mod tests {
 
         peripheral!(
             Max14748,
+            u8,
             0x0A,
             5,
             [
@@ -169,6 +172,7 @@ mod tests {
 
         peripheral!(
             Max14748,
+            u8,
             0x0A,
             5,
             [
@@ -234,6 +238,7 @@ mod tests {
 
         peripheral!(
             Max17261,
+            u8,
             0x36,
             4,
             [
@@ -324,8 +329,9 @@ mod tests {
 
         peripheral!(
             Max14748,
+            u8,
             0x0A,
-            8,
+            9,
             [
                 (ChipId, 0x00, 0),
                 (ChipRev, 0x01, 1),


### PR DESCRIPTION
0.5.0 Changes

**The `peripheral!` macro now requires an additional argument, the type of the address** - This is used to create a map of addresses vs. index. The arose with the Max17261 where the address space is non-liner, in this case the addressing skipped from 0x4F to 0xB0 and again from 0xBF to 0xD0. The `peripheral!` macro stores the registers contiguously in memory as they are listed, so an additional map of index vs. address was needed to correctly access the non-linearly addressed registers.
Replaced `direct_update` with `direct_update_by_address` - This utilized the new index / address array to find the correct register by address. 
Added `find_index_by_address` which attempts to find index based on the address.
Updated examples and tests
